### PR TITLE
Bind to random port

### DIFF
--- a/t/MockServer.pm
+++ b/t/MockServer.pm
@@ -3,20 +3,19 @@ use strict;
 use IO::Socket::INET;
 use IO::Select;
 
-use constant PORT => 8125;
-
 $| = 1;
 
 use vars qw ($socket @messages $select);
 
 sub start {
     $socket = new IO::Socket::INET(
-        LocalPort => PORT,
+        LocalAddr => '127.0.0.1',
         Proto     => 'udp',
     ) or die "unable to create socket: $!\n";
     
     $select = IO::Select->new($socket);
     reset_messages();
+    return $socket->sockport(); 
 }
 
 my $_data = "";
@@ -94,7 +93,7 @@ sub reset_messages { @messages = () }
 
 sub stop {
     my $s_send = IO::Socket::INET->new(
-        PeerAddr  => '127.0.0.1:'. PORT,
+        PeerAddr  => '127.0.0.1:'. $socket->sockport(),
         Proto     => 'udp',
     ) or die "failed to create client socket: $!\n";
     $s_send->send("quit");

--- a/t/mock-server.t
+++ b/t/mock-server.t
@@ -32,11 +32,6 @@ BEGIN {
 use lib $dirname;
 use MockServer;
 
-BEGIN {
-    $Net::Statsd::HOST = 'localhost';
-    $Net::Statsd::PORT = MockServer::PORT();
-}
-
 note <<"DESCRIPTION";
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 These test verify basic operation of the statsd client
@@ -44,7 +39,7 @@ by validating the udp messages sent to a mock server
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 DESCRIPTION
 
-MockServer::start();
+$Net::Statsd::PORT = MockServer::start();
 my $msgs;
 
 Net::Statsd::timing('test.timer', 345);


### PR DESCRIPTION
We ran into an issue running the tests to install Net::Statsd when we have a real statsd server running on the default port. This patch will allow the test to open a socket on random port for the mock server.
